### PR TITLE
Deprecate the queue_on_teleport name in favor of queueonteleport

### DIFF
--- a/api/misc/queue_on_teleport.md
+++ b/api/misc/queue_on_teleport.md
@@ -1,9 +1,0 @@
-# queue_on_teleport
-**Signature:** `queue_on_teleport(script: string)` <br>
-**Aliases:** queueonteleport <br>
-**Description:** Executes script upon successful teleport. <br>
-**Example:**
-```lua
-queue_on_teleport("loadstring(game:HttpGet('https://raw.githubusercontent.com/EdgeIY/infiniteyield/master/source'))()")
-game:GetService("TeleportService"):Teleport(game.PlaceId, game.Players.LocalPlayer)
-```

--- a/api/misc/queueonteleport.md
+++ b/api/misc/queueonteleport.md
@@ -1,0 +1,12 @@
+# queueonteleport
+**Signature:** `queueonteleport(script: string)` <br>
+**Aliases:** N/A <br>
+**Description:** Executes script upon successful teleport. <br>
+**Example:**
+```lua
+queueonteleport("loadstring(game:HttpGet('https://raw.githubusercontent.com/EdgeIY/infiniteyield/master/source'))()")
+game:GetService("TeleportService"):Teleport(game.PlaceId, game.Players.LocalPlayer)
+```
+
+### Note:
+The alias `queue_on_teleport` is not supported by the UNC.


### PR DESCRIPTION
None of the other API uses underscores so this will help consistency.