### PR TITLE
RFC: Add `debug.getmetatable` and `debug.setmetatable`

### DIFF
--- a/api/debug.md
+++ b/api/debug.md
@@ -403,3 +403,49 @@ end)
 
 foo() --> Hello, world!
 ```
+
+---
+
+## debug.getmetatable
+
+```lua
+function debug.getmetatable(object: table): table
+```
+
+Returns the metatable of `object`, where the `__metatable` field would normally lock the metatable.
+
+### Parameters
+
+ * `object` - An object with a metatable.
+
+### Example
+
+```lua
+local object = setmetatable({}, { __metatable = "Locked!" })
+print(getmetatable(object)) --> Locked!
+print(debug.getmetatable(object)) --> table
+```
+
+---
+
+## setrawmetatable
+
+```lua
+function debug.setmetatable(object: table, metatable: table): ()
+```
+
+Sets the metatable of `object` to `metatable`, where the `__metatable` field would normally lock the metatable.
+
+### Parameters
+
+ * `object` - A table or userdata.
+ * `metatable` - The metatable to set.
+
+### Example
+
+```lua
+local object = setmetatable({}, {})
+print(getmetatable(object)) --> table
+debug.setmetatable(object, { __metatable = "Hello, world!" })
+print(getmetatable(object)) --> Hello, world!
+```


### PR DESCRIPTION
# Add `debug.getmetatable` and `debug.setmetatable`

## Summary

Add `debug.getmetatable` and `debug.setmetatable` functions which have the same behavior as `getrawmetatable` and `setrawmetatable`.

## Motivation

Vanilla Lua uses `debug.getmetatable` and `debug.setmetatable`, some executors have them also. It would be good to have more compatibility with vanilla Lua as it's odd that there are functions that to the exact same thing as their vanilla Lua counterparts but have a different name.

## Design

- `debug.getmetatable` functions the same as `getrawmetatable`. ie. it always returns the real metatable of the object even if it is spoofed via `__metatable` metamethod.
- `debug.setmetatable` functions the same as `setrawmetatable`. ie. it always sets the real metatable of the object even if it is spoofed via `__metatable` metamethod.

## Drawbacks

Not much, have to add both the functions to the `debug.` library.

## Alternatives

The alternative is just to use `getrawmetatable` and `setrawmetatable`. The impact of using them is small but it's still a good thing to have functions be on par with vanilla Lua.