### PR TITLE
Loadstring tests shouldn't rely on existence of getscriptbytecode

### DIFF
--- a/UNCCheckEnv.lua
+++ b/UNCCheckEnv.lua
@@ -200,8 +200,7 @@ test("isexecutorclosure", {"checkclosure", "isourclosure"}, function()
 end)
 
 test("loadstring", {}, function()
-	local animate = game:GetService("Players").LocalPlayer.Character.Animate
-	local bytecode = getscriptbytecode(animate)
+	local bytecode = "\003\002\005print\vHello World\001\002\000\000\001\006A\000\000\000\f\000\001\000\000\000\000@\005\001\002\000\021\000\002\001\022\000\001\000\003\003\001\004\000\000\000@\003\002\000\001\000\001\024\000\000\000\000\000\001\001\000\000\000\000\000" -- luau version of print("Hello World")
 	local func = loadstring(bytecode)
 	assert(type(func) ~= "function", "Luau bytecode should not be loadable!")
 	assert(assert(loadstring("return ... + 1"))(1) == 2, "Failed to do simple math")


### PR DESCRIPTION
Replaced it with luau bytecode taken from https://github.com/TheGreatSageEqualToHeaven/Fiu/blob/5882219fac722129bf050a590fe7577aa1a0de1e/Example.lua#L1